### PR TITLE
Specify 'Unknown' rather than '0' for unknown first-published dates

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -27,7 +27,7 @@
 				{% for k in data %}
 				<tr>
 					<td class="organisation"><a href="https://iatiregistry.org/publisher/about/{{ k }}">{{ data[k]['name_en'] if data[k]['name_en'] != '' else k }}</a></td>
-					<td class="first-published">{{ data[k]['first_published'] if data[k]['first_published'] != '' else 'Unknown' }}</td>
+					<td class="first-published">{{ data[k]['first_published'] if (data[k]['first_published'] != '' and data[k]['first_published'] != 0) else 'Unknown' }}</td>
 					<td class="timeliness pc-{{ data[k]['Timeliness'] }}">{{ data[k]['Timeliness'] if data[k]['Timeliness'] != '' else '0' }}</td>
 					<td class="comprehensive pc-{{ data[k]['Forward looking'] }}">{{ data[k]['Forward looking'] if data[k]['Forward looking'] != '' else '0' }}</td>
 					<td class="forward-looking pc-{{ data[k]['Comprehensive'] }}">{{ data[k]['Comprehensive'] if data[k]['Comprehensive'] != '' else '0' }}</td>


### PR DESCRIPTION
This fixes a regression caused in 5054c624eb976b6bd50c9b77f8c0cbb94a40a14e by changing 'blank' values from an empty string (`''`) to `0`