### PR TITLE
Show all signatories

### DIFF
--- a/src/parse_data.py
+++ b/src/parse_data.py
@@ -1,6 +1,7 @@
 import collections
 import csv
 import os
+import uuid
 
 # local configuration
 data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data')
@@ -54,6 +55,9 @@ def publisherify_data(base_info, summary_stats, humanitarian_stats):
 	# parse the static base info about publishers
 	for row in base_info:
 		registry_id = row['registry_id']
+		# create a fake registry ID for those who are not yet publishing so that they are displayed as a row in the table
+		if len(registry_id.strip()) is 0:
+			registry_id = uuid.uuid4()
 		stats = ['baseline', 'first_published', 'name_en']
 		for stat in stats:
 			data[registry_id][stat] = row[stat]

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -26,7 +26,15 @@
 			<tbody class="list">
 				{% for k in data %}
 				<tr>
-					<td class="organisation"><a href="https://iatiregistry.org/publisher/about/{{ k }}">{{ data[k]['name_en'] if data[k]['name_en'] != '' else k }}</a></td>
+					<td class="organisation">
+						{% if (data[k]['first_published'] != '' and data[k]['first_published'] != 0) %}
+							<a href="https://iatiregistry.org/publisher/about/{{ k }}">
+						{% endif %}
+						{{ data[k]['name_en'] if data[k]['name_en'] != '' else k }}
+						{% if (data[k]['first_published'] != '' and data[k]['first_published'] != 0) %}
+							</a>
+						{% endif %}
+					</td>
 					<td class="first-published">{{ data[k]['first_published'] if (data[k]['first_published'] != '' and data[k]['first_published'] != 0) else 'Unknown' }}</td>
 					<td class="timeliness pc-{{ data[k]['Timeliness'] }}">{{ data[k]['Timeliness'] if data[k]['Timeliness'] != '' else '0' }}</td>
 					<td class="comprehensive pc-{{ data[k]['Forward looking'] }}">{{ data[k]['Forward looking'] if data[k]['Forward looking'] != '' else '0' }}</td>

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -26,7 +26,7 @@
 			<tbody class="list">
 				{% for k in data %}
 				<tr>
-					<td class="organisation">
+					<td class="organisation" data-order="{{ data[k]['name_en'] if data[k]['name_en'] != '' else k }}">
 						{% if (data[k]['first_published'] != '' and data[k]['first_published'] != 0) %}
 							<a href="https://iatiregistry.org/publisher/about/{{ k }}">
 						{% endif %}


### PR DESCRIPTION
This causes all signatories (those in the `base_info` CSV) to display in the table whether they are currently publishing or not.

Generation of UUIDs as placeholder `registry_id`s is used since it'll be a unique value, and can be added without modifying the logic to match with other CSVs (as would happen if `name_en` was used as a primary key).