### PR TITLE
Update name of Belgian Development Cooperation

### DIFF
--- a/data/static/base_info.csv
+++ b/data/static/base_info.csv
@@ -1,6 +1,6 @@
 name_en,first_published,org_type,registry_id,baseline
 Australia - Department of Foreign Affairs and Trade (DFAT),2011-09-02,Government,ausgov,37.5
-"Belgium - Foreign Affairs, Foreign Trade and Development Cooperation",2014-12-15,Government,be-dgd,23.95
+Belgian Development Cooperation,2014-12-15,Government,be-dgd,23.95
 British Red Cross,2012-08-16,International NGO,gb-chc-220949,39.5
 Bulgaria,,Government,,0
 Canada - Global Affairs Canada | Affaires mondiales Canada,2012-10-31,Government,gac-amc,53.45


### PR DESCRIPTION
The Belgian Development Cooperation have recently updated their name on the Registry. This change of name also needs to be reflected on the Grand Bargain dashboard. Therefore, please update the name of 'Belgium - Foreign Affairs, Foreign Trade and Development Cooperation' to 'Belgian Development Cooperation'