### PR TITLE
Remove ICVA from Grand Bargain monitoring

### DIFF
--- a/data/static/base_info.csv
+++ b/data/static/base_info.csv
@@ -20,7 +20,6 @@ Germany - Federal Ministry for Economic Cooperation and Development (BMZ),2013-0
 Global Communities,,International NGO,,0
 InterAction,2015-03-19,International NGO,interaction,25.75
 International Committee of the Red Cross (ICRC),,International NGO,,0
-International Council of Voluntary Agencies (ICVA),,National NGO,,0
 International Federation of Red Cross and Red Crescent Societies (IFRC),,International NGO,,0
 International Labor Organization (ILO),2016-04-18,Multilateral,ilo,0
 International Organization for Migration (IOM),,Multilateral,,0


### PR DESCRIPTION
On advice from @wendyrogers this organisation will no longer form
part of the Grand Bargain process.