### PR TITLE
Split 'Summary' page into 2 separate 'tab' pages 'Summary' & 'Details'

### DIFF
--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -27,3 +27,7 @@ h1 {
 	font-family: geomanist, Arial, sans-serif;
 	font-weight: bold;
 }
+
+div.dataTables_filter {
+  margin-bottom: 20px;  /* Add extra whitespace below table 'Search' box. */
+}

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -57,7 +57,7 @@
 
 	<div role="tabpanel" class="tab-pane" id="details-tab">
 		<h2></h2>
-		<p>This page provides individual assessment values for the five performance measures (identified within the framework and methodology for measuring the quality of humanitarian data published to IATI). Please see the 'Methodology' tab for details on how each measure is assessed and hover over column headings for a brief description.</p>
+		<p>This page provides individual assessment values for the five performance measures (identified within the framework and methodology for measuring the quality of humanitarian data published to IATI). Please see the 'Methodology' tab for details on how each measure is assessed or hover over column headings for a brief description.</p>
 
 		<table class="table">
 			<thead>

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -3,6 +3,7 @@
 
 <ul class="nav nav-tabs" role="tablist">
 	<li role="presentation" class="active"><a href="#summary-tab" aria-controls="summary" role="tab" data-toggle="tab">Summary</a></li>
+	<li role="presentation"><a href="#details-tab" aria-controls="details" role="tab" data-toggle="tab">Details</a></li>
 	<li role="presentation"><a href="#methodology-tab" aria-controls="data-use" role="tab" data-toggle="tab">Methodology</a></li>
 </ul>
 
@@ -64,6 +65,11 @@
 				{% endfor %}
 			</tbody>
 		</table>
+	</div>
+
+	<div role="tabpanel" class="tab-pane" id="details-tab">
+		<h2></h2>
+		<p>This page provides individual assessment values for the five performance measures (identified within the framework and methodology for measuring the quality of humanitarian data published to IATI). Please see the ‘Methodology’ tab for details on how each measure is assessed and hover over column headings for a brief description.</p>
 	</div>
 
 	<div role="tabpanel" class="tab-pane" id="methodology-tab">

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -30,12 +30,6 @@
 				<tr>
 					<th class="sort" data-sort="organisation">Organisation</th>
 					<th class="sort" data-sort="first-published">First Published</th>
-					<th class="sort" data-sort="timeliness">Timeliness</th>
-					<th class="sort" data-sort="forward-looking">Forward Looking</th>
-					<th class="sort" data-sort="comprehensive">Comprehensive</th>
-					<th class="sort" data-sort="coverage">Coverage</th>
-					<th class="sort" data-sort="humanitarian">Humanitarian</th>
-					<th class="sort" data-sort="total">Total</th>
 					<th class="sort" data-sort="progress">Progress</th>
 					<th class="sort" data-sort="baseline">Baseline</th>
 				</tr>
@@ -53,12 +47,6 @@
 						{% endif %}
 					</td>
 					<td class="first-published">{{ data[k]['first_published'] if (data[k]['first_published'] != '' and data[k]['first_published'] != 0) else 'Unknown' }}</td>
-					<td class="timeliness pc-{{ data[k]['Timeliness'] }}">{{ data[k]['Timeliness'] if data[k]['Timeliness'] != '' else '0' }}</td>
-					<td class="comprehensive pc-{{ data[k]['Forward looking'] }}">{{ data[k]['Forward looking'] if data[k]['Forward looking'] != '' else '0' }}</td>
-					<td class="forward-looking pc-{{ data[k]['Comprehensive'] }}">{{ data[k]['Comprehensive'] if data[k]['Comprehensive'] != '' else '0' }}</td>
-					<td class="coverage pc-{{ data[k]['humanitarian_coverage_total'] }}">{{ data[k]['humanitarian_coverage_total'] if data[k]['humanitarian_coverage_total'] else '0' }}</td>
-					<td class="humanitarian pc-{{ data[k]['humanitarian'] }}">{{ data[k]['humanitarian'] if data[k]['humanitarian'] != '' else '0' }}</td>
-					<td class="summary-total">{{ data[k]['summary_total']|round(2) if data[k]['summary_total'] != '' else '0' }}</td>
 					<td class="{{ 'positive-progress' if data[k]['progress'] > 0 }}">{{ data[k]['progress']|round(2) if data[k]['progress'] != '' else '0' }}</td>
 					<td class="baseline">{{ data[k]['baseline'] if data[k]['baseline'] != '' else '0' }}</td>
 				</tr>
@@ -69,7 +57,42 @@
 
 	<div role="tabpanel" class="tab-pane" id="details-tab">
 		<h2></h2>
-		<p>This page provides individual assessment values for the five performance measures (identified within the framework and methodology for measuring the quality of humanitarian data published to IATI). Please see the ‘Methodology’ tab for details on how each measure is assessed and hover over column headings for a brief description.</p>
+		<p>This page provides individual assessment values for the five performance measures (identified within the framework and methodology for measuring the quality of humanitarian data published to IATI). Please see the 'Methodology' tab for details on how each measure is assessed and hover over column headings for a brief description.</p>
+
+		<table class="table">
+			<thead>
+				<tr>
+					<th class="sort" data-sort="organisation">Organisation</th>
+					<th class="sort" data-sort="timeliness">Timeliness</th>
+					<th class="sort" data-sort="forward-looking">Forward Looking</th>
+					<th class="sort" data-sort="comprehensive">Comprehensive</th>
+					<th class="sort" data-sort="coverage">Coverage</th>
+					<th class="sort" data-sort="humanitarian">Humanitarian</th>
+					<th class="sort" data-sort="total">Total</th>
+				</tr>
+			</thead>
+			<tbody class="list">
+				{% for k in data %}
+				<tr>
+					<td class="organisation" data-order="{{ data[k]['name_en'] if data[k]['name_en'] != '' else k }}">
+						{% if (data[k]['first_published'] != '' and data[k]['first_published'] != 0) %}
+							<a href="https://iatiregistry.org/publisher/about/{{ k }}">
+						{% endif %}
+						{{ data[k]['name_en'] if data[k]['name_en'] != '' else k }}
+						{% if (data[k]['first_published'] != '' and data[k]['first_published'] != 0) %}
+							</a>
+						{% endif %}
+					</td>
+					<td class="timeliness pc-{{ data[k]['Timeliness'] }}">{{ data[k]['Timeliness'] if data[k]['Timeliness'] != '' else '0' }}</td>
+					<td class="comprehensive pc-{{ data[k]['Forward looking'] }}">{{ data[k]['Forward looking'] if data[k]['Forward looking'] != '' else '0' }}</td>
+					<td class="forward-looking pc-{{ data[k]['Comprehensive'] }}">{{ data[k]['Comprehensive'] if data[k]['Comprehensive'] != '' else '0' }}</td>
+					<td class="coverage pc-{{ data[k]['humanitarian_coverage_total'] }}">{{ data[k]['humanitarian_coverage_total'] if data[k]['humanitarian_coverage_total'] else '0' }}</td>
+					<td class="humanitarian pc-{{ data[k]['humanitarian'] }}">{{ data[k]['humanitarian'] if data[k]['humanitarian'] != '' else '0' }}</td>
+					<td class="summary-total">{{ data[k]['summary_total']|round(2) if data[k]['summary_total'] != '' else '0' }}</td>
+				</tr>
+				{% endfor %}
+			</tbody>
+		</table>
 	</div>
 
 	<div role="tabpanel" class="tab-pane" id="methodology-tab">


### PR DESCRIPTION
Adds a new tab 'Details' and restructures table columns as follows

- 'Summary' tab containing columns: Organisation, First Published (see also below), Progress & Baseline
- 'Details' tab containing columns: Organisation, Timeliness, Forward-Looking, Comprehensive, Coverage, Humanitarian & Total

~Temporary live preview: http://0fd95ec7.ngrok.io/dashboard~ < No longer active