### PR TITLE
Add link to DI baseline report

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -12,7 +12,7 @@
 
 		<h2></h2>
 
-		<p>This bespoke dashboard was developed by <a href="http://devinit.org/">Development Initiatives</a> (DI) to support the Grand Bargain <a href="https://interagencystandingcommittee.org/greater-transparency">workstream on transparency</a> in taking forward commitments made by signatories at the World Humanitarian Summit 2016. It is part of the project <strong>Monitoring the Grand Bargain commitment on transparency</strong>. The dashboard is based on a framework and methodology for measuring the quality of humanitarian data published to IATI which is proposed in DI’s baseline report, <strong>Implementing and monitoring the Grand Bargain commitment on transparency</strong>, and subject to final approval.</p>
+		<p>This bespoke dashboard was developed by <a href="http://devinit.org/">Development Initiatives</a> (DI) to support the Grand Bargain <a href="https://interagencystandingcommittee.org/greater-transparency">workstream on transparency</a> in taking forward commitments made by signatories at the World Humanitarian Summit 2016. It is part of the project <strong>Monitoring the Grand Bargain commitment on transparency</strong>. The dashboard is based on a framework and methodology for measuring the quality of humanitarian data published to IATI which is proposed in DI’s baseline report, <strong><a href="http://devinit.org/post/baseline-report-implementing-and-monitoring-the-grand-bargain-commitment-on-transparency/#">Implementing and monitoring the Grand Bargain commitment on transparency</a></strong>, and subject to final approval.</p>
 
 		<p>It is a tool that enables <a href="http://www.agendaforhumanity.org/initiatives/3861">Grand Bargain signatories</a> to:</p>
 			<ol>


### PR DESCRIPTION
Adds a link to DI baseline report: [Implementing and monitoring the Grand Bargain commitment on transparency](http://devinit.org/post/baseline-report-implementing-and-monitoring-the-grand-bargain-commitment-on-transparency/#).

Following this change, the intro text looks like this:

![image](https://user-images.githubusercontent.com/8247168/34482920-13e608bc-efb3-11e7-9304-0353ab6c270b.png)
