### PR TITLE
Italy- name update required

### DIFF
--- a/data/static/base_info.csv
+++ b/data/static/base_info.csv
@@ -27,7 +27,7 @@ International Organization for Migration (IOM),,Multilateral,,0
 International Rescue Committee (IRC),2017-09-12,International NGO,irc_inc,0
 International Rescue Committee (IRC) UK,2014-02-11,International NGO,irc_uk,0
 Ireland - Department of Foreign Affairs & Trade (Irish Aid),2013-07-31,Government,irishaid,6.25
-Italy - Ministry of Foreign Affairs and International Cooperation,2017-10-18,Government,aics,0
+AICS - Agenzia Italiana per la Cooperazione allo Sviluppo / Italian Agency for Cooperation and Development,2017-10-18,Government,aics,0
 Japan - Japan International Cooperation Agency (JICA),2014-06-30,Government,jica,25.75
 Luxembourg,,Government,,0
 Mercy Corps Europe,2012-07-02,International NGO,mce,0


### PR DESCRIPTION
The name of the publisher does not match the current name on the IATI Registry. It is now AICS - Agenzia Italiana per la Cooperazione allo Sviluppo / Italian Agency for Cooperation and Development. Please approve and update.