### PR TITLE
Added gbm-dev config in inventory.ini

### DIFF
--- a/deployment/inventory.ini
+++ b/deployment/inventory.ini
@@ -6,3 +6,11 @@ grand-bargain-monitoring-live	ansible_host=46.101.46.6	ansible_user=root
 
 [gbm-live:vars]
 ansible_python_interpreter=/usr/bin/python3
+
+# Dev server for Grand Bargain Monitoring
+[gbm-dev]
+grand-bargain-monitoring-dev    ansible_host=167.99.95.30   ansible_user=root
+
+[gbm-dev:vars]
+ansible_python_interpreter=/usr/bin/python3
+


### PR DESCRIPTION
PRd directly into master as it's just a couple of inert extra lines in `inventory.ini`

I don't know enough about ansible to confidently change the other scripts to accept a parametrised version of the hostname, so for now to deploy in either `dev` or `live`you'd have to find/replace gbm-live with gbm-dev

Or point me in the right direction, Ansible documentation wise, to update this PR properly